### PR TITLE
Add details about Official Production

### DIFF
--- a/docs/source/production.rst
+++ b/docs/source/production.rst
@@ -1,5 +1,86 @@
 Official Production
 ====================
 
-.. caution::
-  This page is currently not created, coming soon! If you would like to contribute, reach `me <helena.almamol@gmail.com>`_!
+This page collects all the information related to the official simulation production of NEXT detectors.
+
+.. warning::
+  This webpage is still under construction. If you would like to contribute, reach `me <helena.almamol@gmail.com>`_!
+
+
+NEXT-White
+------------
+Latest official production was generated using
+
+.. list-table::
+   :widths: 40 60
+   :header-rows: 0
+
+   * - **nexus**
+     - ``to be added``
+   * - **detsim**
+     - ``to be added``
+   * - **IC**
+     - ``to be added``
+   * - **Background Model**
+     - ``to be added``
+
+It can be found in ``neutrinos1.ific.uv.es`` under the following path:
+
+.. code-block:: text
+
+  /lustre/neu/data4/NEXT/NEXTNEW/MC/
+
+For the different productions the corresponding latest tags are:
+
+.. list-table::
+   :widths: 40 60
+   :header-rows: 1
+
+   * - Production
+     - Tag
+   * - **0nubb**
+     - ``NEXT_v1_05_02_NEXUS_v5_07_00_bkg_v9``
+   * - **Xe2nu**
+     - ``NEXT_v1_05_02_NEXUS_v5_07_10_bkg_v9``
+   * - **Calibration**
+     - ``NEXT_v1_05_02_NEXUS_v5_07_10_bkg_v9``
+   * - **Background**
+     - ``NEXT_v1_05_02_NEXUS_v5_07_10_bkg_v9``
+
+
+Output hdf5 files together with the corresponding config files used to run each of the cities can be found there. E.g. the background production of deconvoluted hits (``cdst``) can be found in
+
+.. code-block:: text
+
+  /lustre/neu/data4/NEXT/NEXTNEW/MC/Background/NEXT_v1_05_02_NEXUS_v5_07_10_bkg_v9/cdst/output
+
+Where the following config files have been used,
+
+.. code-block:: text
+
+  /lustre/neu/data4/NEXT/NEXTNEW/MC/Background/NEXT_v1_05_02_NEXUS_v5_07_10_bkg_v9/cdst/conf
+
+
+
+NEXT-100
+------------
+This sample is currently being produced. It is generated using
+
+.. list-table::
+   :widths: 40 60
+   :header-rows: 0
+
+   * - **nexus**
+     - ``to be added``
+   * - **detsim**
+     - ``to be added``
+   * - **IC**
+     - ``to be added``
+   * - **Background Model**
+     - ``to be added``
+
+Detsim light tables (LTs) and pulse shape functions (PSFs) can be found in ``neutrinos1.ific.uv.es`` in
+
+.. code-block:: text
+
+  /data5/users/gdiaz/NEXT100/kr83m/LightTables

--- a/docs/source/production.rst
+++ b/docs/source/production.rst
@@ -81,10 +81,10 @@ This sample is currently being produced. It is generated using
 
 **Nexus macros** for the current production can be found on GitHub `here <https://github.com/gondiaz/NEXT100-0nubb-analysis/tree/main/nexus_job_templates/ft3>`_.
 
-Detsim *light tables* (**LTs**) and *pulse shape functions* (**PSFs**) can be found in ``neutrinos1.ific.uv.es`` in
+Detsim *light tables* (**LTs**) and *point spread functions* (**PSFs**) can be found in ``neutrinos1.ific.uv.es`` in
 
 .. code-block:: text
 
   /data5/users/gdiaz/NEXT100/kr83m/LightTables
 
-**Config** files for the rest of the production chain can also be found on `here <https://github.com/gondiaz/NEXT100-0nubb-analysis/tree/main/ic_processing/templates>`_ on Github. 
+**Config** files for the rest of the production chain can also be found on `here <https://github.com/gondiaz/NEXT100-0nubb-analysis/tree/main/ic_processing/templates>`_ on Github.

--- a/docs/source/production.rst
+++ b/docs/source/production.rst
@@ -30,7 +30,7 @@ It can be found in ``neutrinos1.ific.uv.es`` under the following path:
 
   /lustre/neu/data4/NEXT/NEXTNEW/MC/
 
-For the different productions the corresponding latest tags are:
+For the different productions the corresponding latest **tags** are:
 
 .. list-table::
    :widths: 40 60
@@ -48,13 +48,13 @@ For the different productions the corresponding latest tags are:
      - ``NEXT_v1_05_02_NEXUS_v5_07_10_bkg_v9``
 
 
-Output hdf5 files together with the corresponding config files used to run each of the cities can be found there. E.g. the background production of deconvoluted hits (``cdst``) can be found in
+**Output hdf5** files together with the corresponding config files used to run each of the cities can be found there. E.g. the background production of deconvoluted hits (``cdst``) can be found in
 
 .. code-block:: text
 
   /lustre/neu/data4/NEXT/NEXTNEW/MC/Background/NEXT_v1_05_02_NEXUS_v5_07_10_bkg_v9/cdst/output
 
-Where the following config files have been used,
+Where the following **config** files have been used,
 
 .. code-block:: text
 
@@ -79,8 +79,12 @@ This sample is currently being produced. It is generated using
    * - **Background Model**
      - ``to be added``
 
-Detsim light tables (LTs) and pulse shape functions (PSFs) can be found in ``neutrinos1.ific.uv.es`` in
+**Nexus macros** for the current production can be found on GitHub `here <https://github.com/gondiaz/NEXT100-0nubb-analysis/tree/main/nexus_job_templates/ft3>`_.
+
+Detsim *light tables* (**LTs**) and *pulse shape functions* (**PSFs**) can be found in ``neutrinos1.ific.uv.es`` in
 
 .. code-block:: text
 
   /data5/users/gdiaz/NEXT100/kr83m/LightTables
+
+**Config** files for the rest of the production chain can also be found on `here <https://github.com/gondiaz/NEXT100-0nubb-analysis/tree/main/ic_processing/templates>`_ on Github. 

--- a/docs/source/production.rst
+++ b/docs/source/production.rst
@@ -1,7 +1,7 @@
 Official Production
 ====================
 
-This page collects all the information related to the official simulation production of NEXT detectors.
+This page collects all the information related to the official **simulation** production of NEXT detectors.
 
 .. warning::
   This webpage is still under construction. If you would like to contribute, reach `me <helena.almamol@gmail.com>`_!
@@ -16,13 +16,17 @@ Latest official production was generated using
    :header-rows: 0
 
    * - **nexus**
-     - ``to be added``
+     - ``v5_07_00``/``v5_07_01``
    * - **detsim**
-     - ``to be added``
-   * - **IC**
-     - ``to be added``
+     - ``v0_09_01``
+   * - **IC: diomira, irene, and dorothea**
+     - ``v1.1.0``
+   * - **IC: penthesilea**
+     - ``v1.2.0``
+   * - **IC: isaura**
+     - ``v1.2.alberto``
    * - **Background Model**
-     - ``to be added``
+     - ``v9``
 
 It can be found in ``neutrinos1.ific.uv.es`` under the following path:
 
@@ -37,7 +41,7 @@ For the different productions the corresponding latest **tags** are:
    :header-rows: 1
 
    * - Production
-     - Tag
+     - Folder
    * - **0nubb**
      - ``NEXT_v1_05_02_NEXUS_v5_07_00_bkg_v9``
    * - **Xe2nu**
@@ -61,6 +65,13 @@ Where the following **config** files have been used,
   /lustre/neu/data4/NEXT/NEXTNEW/MC/Background/NEXT_v1_05_02_NEXUS_v5_07_10_bkg_v9/cdst/conf
 
 
+.. note::
+  It is important to stress some aspects regarding the production:
+    * The production is based on the v9 version of the background model. The details of the model can be found `here <https://next.ific.uv.es/cgi-bin/DocDB/private/ShowDocument?docid=182>`_.
+    * The two versions of ``nexus`` are completelly analogous but for an update concerning the calibration ports.
+    * The detsim package refers to the ``c++`` and ``art`` version. The repository may be found `here <https://next.ific.uv.es:8888/nextsw/detsim>`_.
+    * The EventMixer package refers to the ``gate`` version. The repository may be found `here <https://next.ific.uv.es:8888/nextsw/PyToNE/blob/master/PyToNE/EventMixer.py>`_.
+    * The IC package is considered in different versions since the goal is to match the official Canfranc production for data (``v1.1.0``). However, several updates implied the usage of more recent versions, even a custom one before the officialization of ``ìsaura``.
 
 NEXT-100
 ------------


### PR DESCRIPTION
This PR updates the Official Production page. It includes the information related to NEW, and current macros and config files used for NEXT-100 production:

https://pr004-sw-docs.readthedocs.io/en/latest/production.html

NEW production is still missing some details related nexus/IC/Background Model that would like to include before it is merged (@ausonandres, @bpalmeiro). Since NEXT-100 is still being produced, this section can stay in this stage until production is more advanced. 