### PR TITLE
Clarify that ROOT is not needed anymore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.DS_Store
+docs/.DS_Store
+docs/build
+
+*~

--- a/docs/source/NEXUS.rst
+++ b/docs/source/NEXUS.rst
@@ -33,9 +33,7 @@ Important information about NEXUS code:
 Tags
 ------------
 A list of the different NEXUS `tags <https://github.com/next-exp/nexus/wiki/Tags>`_ can be found on the Wiki.
-Starting from nexus tag v7_00_00, Geant4 version >= 11.0 is needed:
-
-For previous nexus tags,  ROOT >= 6.26 must be used.
+Starting from nexus tag v7_00_00, Geant4 version >= 11.0 is needed; for previous nexus tags,  ROOT >= 6.26 must be used.
 
  .. note::
    Geant4 version 10.7.x cannot be used with any nexus tag or even commit. For previous tags, Geant4.10.6 or Geant4.10.5 were used.

--- a/docs/source/NEXUS.rst
+++ b/docs/source/NEXUS.rst
@@ -33,10 +33,9 @@ Important information about NEXUS code:
 Tags
 ------------
 A list of the different NEXUS `tags <https://github.com/next-exp/nexus/wiki/Tags>`_ can be found on the Wiki.
-Starting from nexus tag v7_00_00, the following versions are needed:
+Starting from nexus tag v7_00_00, Geant4 version >= 11.0 is needed:
 
- * Geant4 version >= 11.0.
- * ROOT >= 6.26.
+For previous nexus tags,  ROOT >= 6.26 must be used.
 
  .. note::
    Geant4 version 10.7.x cannot be used with any nexus tag or even commit. For previous tags, Geant4.10.6 or Geant4.10.5 were used.

--- a/docs/source/olivia.rst
+++ b/docs/source/olivia.rst
@@ -1,5 +1,5 @@
 Olivia
-=====
+======
 
 .. caution::
   This page is currently not created, we are working on it. If you would like to contribute on this documentation, reach `me <helena.almamol@gmail.com>`_!

--- a/docs/source/penthesilea.rst
+++ b/docs/source/penthesilea.rst
@@ -1,5 +1,5 @@
 Penthesilea
-==========
+===========
 
 .. caution::
   This page is currently not created, we are working on it. If you would like to contribute on this documentation, reach `me <helena.almamol@gmail.com>`_!


### PR DESCRIPTION
This PR clarifies the text of the NEXUS page regarding the ROOT version needed (up to a certain tag).
It also modifies a couple of other pages to solve compilation warnings and adds a .gitignore file to the repository, which was missing.