### PR TITLE
Adding clarification for blob centre calculation

### DIFF
--- a/docs/source/isaura.rst
+++ b/docs/source/isaura.rst
@@ -160,7 +160,7 @@ Once events are properly selected according to the :ref:`previous subsection <Hi
 **Searching blobs position**
 
 
-To compute the position of the blobs, we need to find the two extreme voxels of the track, which is done following the BFS algorithm. Then, as the figure below illustrates, the energy-weighted averaged position of the hits (represented with red stars) inside these voxels will correspond to the **blob center** (represented with the black dot from where the grey arrow starts).
+To compute the position of the blobs, we need to find the two extreme voxels of the track, which is done following the BFS algorithm. Then, as the figure below illustrates, the energy-weighted averaged position of the hits (represented with red stars) inside each extreme voxel will correspond to the **blob center** (represented with the black dot from where the grey arrow starts).
 
 
 .. image:: images/isaura/blobs_position_definition.png


### PR DESCRIPTION
This is a minor adjustment to the isaura documentation, that alters the section **searching blobs position** to avoid confusion.

Before this change, it was easy to misinterpret the text as meaning that the hits within the voxels surrounding each extreme voxel were used to determine the blob centre, which isn't the case. **Only** the hits within the extreme voxel is used to determine the blob position.