### PR TITLE
Add warning to eutropia

### DIFF
--- a/docs/source/eutropia.rst
+++ b/docs/source/eutropia.rst
@@ -102,12 +102,13 @@ following arguments:
      - ``float``
      - Bin size for :math:`\Delta x` and :math:`\Delta y`.
 
-.. warning:: 
+.. warning::
   A large 'PSF size' (defined by the ``xrange | yrange`` and 
-  ``zbins``) is discouraged. 
+  ``bin_size_xy``) in conjunction with a large number of ``zbins``
+  can cause excessive memory usage.
   To avoid this issue, ensure that your ``xrange | yrange`` do not
   exceed the PSF tails (~100mm for NEXT100), or use a smaller number
-  of ``zbins`` as a PSF is produced for each bin.
+  of ``zbins`` as a unique PSF is produced for each bin.
 
 .. _Eutropia workflow:
 

--- a/docs/source/eutropia.rst
+++ b/docs/source/eutropia.rst
@@ -103,10 +103,11 @@ following arguments:
      - Bin size for :math:`\Delta x` and :math:`\Delta y`.
 
 .. warning:: 
-  The values provided for ``xrange | yrange`` should not exceed 
-  the PSF tails (~100mm for NEXT-100). Having large :math:`\Delta x` 
-  and :math:`\Delta y` values causes excessive memory usage and 
-  slowdown, especially when implementing a large number of ``zbins``.
+  A large 'PSF size' (defined by the ``xrange | yrange`` and 
+  ``zbins``) is discouraged. 
+  To avoid this issue, ensure that your ``xrange | yrange`` do not
+  exceed the PSF tails (~100mm for NEXT100), or use a smaller number
+  of ``zbins`` as a PSF is produced for each bin.
 
 .. _Eutropia workflow:
 

--- a/docs/source/eutropia.rst
+++ b/docs/source/eutropia.rst
@@ -102,6 +102,12 @@ following arguments:
      - ``float``
      - Bin size for :math:`\Delta x` and :math:`\Delta y`.
 
+.. warning:: 
+  The values provided for ``xrange | yrange`` should not exceed 
+  the PSF tails (~100mm for NEXT-100). Having large :math:`\Delta x` 
+  and :math:`\Delta y` values causes excessive memory usage and 
+  slowdown, especially when implementing a large number of ``zbins``.
+
 .. _Eutropia workflow:
 
 Workflow


### PR DESCRIPTION
This PR adds a warning to the eutropia documentation that alerts the user of excessive memory usage/slowdown when the `xrange | yrange`, parameters are set to be too large. This in conjunction with a large number of `zbins` will inevitably cause computational issues and should be avoided if possible.

Hopefully eutropia can be rewritten to avoid this particular issue, but in the meantime a warning is appropriate.

The links can be found [here](https://pr37-sw-docs.readthedocs.io/en/latest/).