### PR TITLE
include newest NEXT-100 productions

### DIFF
--- a/docs/source/production.rst
+++ b/docs/source/production.rst
@@ -114,7 +114,7 @@ Detsim *light tables* (**LTs**) and *point spread functions* (**PSFs**) can be f
 
 **Config** files for the rest of the production chain can also be found on `here <https://github.com/gondiaz/NEXT100-0nubb-analysis/tree/main/ic_processing/templates>`_ on Github.
 
-NEXT-100 (newest production)
+NEXT-100 (30-10-24)
 -----------------------------
 
 A more recent dataset using also fast simulations has been produced for two different vessel pressures: High Pressure Run (HPR) with 13.5 bar and Low Pressure Run (LPR) with 5 bar. 

--- a/docs/source/production.rst
+++ b/docs/source/production.rst
@@ -169,3 +169,47 @@ Where:
 * **isotope:** the name of the simulated isotope, can be :sup:`214`\Bi or :sup:`208`\Tl for radiogenics, for example. 
 * **volumes:** nexus volumes where the isotope was simulated, such as ACTIVE for the Kr calibration, the different calibration ports for HE calibration, or the NEXT-100 detector components for radiogenics.
 * **production:** contains the nexus and IC files, divided in folders by city.
+
+NEXT-100 (20-10-2025)
+-----------------------------
+
+This dataset includes multiple simulations processed for krypton and high energy at 4 bar, all found at `/lustre/neu/data4/NEXT/4bar/`:
+
+.. list-table::
+   :widths: 40 60
+   :header-rows: 0
+
+   * - **nexus:**
+     - ``-`` 
+   * - **nexus: LTs and PSFs for Detsim**
+     - ``-``
+   * - **IC**
+     - ``-``
+   * - **NEXT-100 Background Model**
+     - ``-``
+
+
+.. list-table::
+   :widths: 40 20 60 40
+   :header-rows: 1
+
+   * - Folder name
+     - Type
+     - Description
+     - Processed: 
+   * - ``kr_202503_fullsim/``
+     - Kr 83m - Full sim
+     - **200k events** in NEXT100 active volume. 50ms electron lifetime
+     - nexus, hypathia, dorothea
+   * - ``kr_202502_fullsim/``
+     - Kr 83m - Full sim
+     - **200k events** in NEXT100 active volume. 1000ms electron lifetime
+     - nexus, hypathia, dorothea
+   * - ``kr_202510_fullsim/``
+     - Kr 83m - Full sim
+     - **1M events** in NEXT100 active volume.
+     - hypathia, dorothea
+   * - ``th_port1a_202509/``
+     - Tl 208 - Fast sim
+     - **1.63M events** within 1-2.8 MeV energy window
+     - nexus, sophronia


### PR DESCRIPTION
This PR adds the newest productions to the `production.rst` page, although without the relevant tags for IC, nexus, or the light tables.

Read the docs link will be [here](https://pr39-sw-docs.readthedocs.io/en/latest/production.html#next-100-20-10-2025)